### PR TITLE
Add support and documentation for MapRequestHeaders attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,49 @@ public function authorizedAction()
 **Parameters:**
 - `role` (string): The role required to access the method
 
+### MapRequestHeaders
+The `MapRequestHeaders` attribute maps HTTP request headers to a typed object (DTO) and validates them.
+
+```php
+use LaminasAttributeController\Validation\MapRequestHeaders;
+use Clients\Application\Dto\Document\UploadDocumentHeadersDto;
+
+public function uploadAction(
+    #[MapRequestHeaders(UploadDocumentHeadersDto::class, requiredHeaders: ['x-document-type', 'x-filename', 'x-mime-type', 'x-size'])]
+    UploadDocumentHeadersDto $headers
+) {
+    // $headers is populated from request headers and validated
+    return ['status' => 'headers received'];
+}
+```
+
+This attribute automatically maps and validates the specified headers into the given DTO.
+
+#### Example with Multiple Headers and Validators
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+use Clients\Domain\Document\DocumentType;
+
+final class UploadDocumentHeadersDto
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Choice(callback: [DocumentType::class, 'values'])]
+        public string $xDocumentType,
+        #[Assert\NotBlank]
+        public string $xFilename,
+        #[Assert\NotBlank]
+        public string $xMimeType,
+        #[Assert\NotBlank]
+        public int $xSize,
+    ) {
+    }
+}
+```
+
+Using this DTO with the `MapRequestHeaders` attribute will automatically validate all headers according to the specified constraints. If any required header is missing or invalid, a validation error will be returned.
+
 ### MapRequestPayload
 The `MapRequestPayload` attribute maps the request body to a parameter.
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -18,6 +18,7 @@ use LaminasAttributeController\Security\GuardListener;
 use LaminasAttributeController\Security\NullCurrentUser;
 use LaminasAttributeController\Validation\DefaultValueResolver;
 use LaminasAttributeController\Validation\MapQueryStringResolver;
+use LaminasAttributeController\Validation\MapRequestHeadersResolver;
 use LaminasAttributeController\Validation\MapRequestPayloadResolver;
 use LaminasAttributeController\Validation\QueryParamResolver;
 use Psr\Container\ContainerInterface;
@@ -27,6 +28,7 @@ return [
     'laminas-attribute-controller' => [
         'resolvers' => [
             FromRouteResolver::class,
+            MapRequestHeadersResolver::class,
             MapRequestPayloadResolver::class,
             MapQueryStringResolver::class,
             QueryParamResolver::class,
@@ -40,6 +42,13 @@ return [
         'factories' => [
             FromRouteResolver::class => function (ContainerInterface $container) {
                 return new FromRouteResolver($container->get(EntityManagerInterface::class));
+            },
+            MapRequestHeadersResolver::class => function (ContainerInterface $container) {
+
+                $validator = $container->get(ValidatorInterface::class);
+                $request = $container->get('request');
+
+                return new MapRequestHeadersResolver($validator, $request);
             },
             MapRequestPayloadResolver::class => function (ContainerInterface $container) {
 

--- a/src/Validation/MapRequestHeaders.php
+++ b/src/Validation/MapRequestHeaders.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasAttributeController\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class MapRequestHeaders
+{
+    public function __construct(
+        public string $dtoClass,
+        public array $requiredHeaders = [],
+    ) {
+    }
+}

--- a/src/Validation/MapRequestHeadersResolver.php
+++ b/src/Validation/MapRequestHeadersResolver.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasAttributeController\Validation;
+
+use InvalidArgumentException;
+use Laminas\Http\Request;
+use LaminasAttributeController\ParameterResolverInterface;
+use LaminasAttributeController\ParameterValue;
+use LaminasAttributeController\ResolutionContext;
+use ReflectionClass;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use function class_exists;
+use function count;
+use function filter_var;
+use function in_array;
+use function preg_replace;
+use function strtolower;
+
+final readonly class MapRequestHeadersResolver implements ParameterResolverInterface
+{
+    public function __construct(
+        private ValidatorInterface $validator,
+        private Request $request,
+    ) {
+    }
+
+    public function resolve(ResolutionContext $context): ParameterValue
+    {
+        foreach ($context->getAttributes() as $attribute) {
+            if ($attribute->getName() !== MapRequestHeaders::class) {
+                continue;
+            }
+
+            /** @var MapRequestHeaders $attributeInstance */
+            $attributeInstance = $attribute->newInstance();
+
+            if (! class_exists($attributeInstance->dtoClass)) {
+                throw new InvalidArgumentException("DTO class {$attributeInstance->dtoClass} does not exist.");
+            }
+
+            $reflectionClass = new ReflectionClass($attributeInstance->dtoClass);
+            $constructor = $reflectionClass->getConstructor();
+            $parameters = $constructor?->getParameters() ?? [];
+
+            $args = [];
+            foreach ($parameters as $param) {
+                $headerName = $this->toHeaderName($param->getName());
+
+                if (! $this->request->getHeaders()->has($headerName)) {
+                    if (in_array($headerName, $attributeInstance->requiredHeaders, true)) {
+                        throw new InvalidArgumentException("Missing required header: $headerName");
+                    }
+
+                    $args[] = null;
+                    continue;
+                }
+
+                $headerValue = $this->request->getHeader($headerName)->getFieldValue();
+
+                $typedValue = match ($param->getType()?->getName()) {
+                    'int' => (int) $headerValue,
+                    'float' => (float) $headerValue,
+                    'bool' => filter_var($headerValue, FILTER_VALIDATE_BOOLEAN),
+                    default => $headerValue,
+                };
+
+                $args[] = $typedValue;
+            }
+
+            $dto = $reflectionClass->newInstanceArgs($args);
+
+            $violations = $this->validator->validate($dto);
+            if (count($violations) > 0) {
+                throw new ApiSymfonyValidatorChainException($violations);
+            }
+
+            return ParameterValue::found(MapRequestHeaders::class, $dto);
+        }
+
+        return ParameterValue::notFound();
+    }
+
+    private function toHeaderName(string $property): string
+    {
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $property));
+    }
+}


### PR DESCRIPTION
This PR introduces the MapRequestHeaders attribute to the codebase, enabling automatic mapping and validation of HTTP request headers into typed DTOs for controller actions.

Implements MapRequestHeaders attribute and its resolver (MapRequestHeadersResolver)
Allows specifying required headers and DTO class for mapping
Integrates Symfony validation for header DTOs
Adds comprehensive documentation to README.md, styled consistently with other attribute sections
Provides usage examples and DTO validation patterns
This enhances controller parameter handling by supporting structured and validated header input.