### PR TITLE
Fix/tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
     "psr-4": {
       "LaminasAttributeController\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
   }
 }

--- a/tests/Stubs/Entity.php
+++ b/tests/Stubs/Entity.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+final readonly class Entity
+{
+    public function __construct(private int $id)
+    {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Stubs/StubService.php
+++ b/tests/Stubs/StubService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+final class StubService implements StubServiceInterface
+{
+}

--- a/tests/Stubs/StubServiceInterface.php
+++ b/tests/Stubs/StubServiceInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+interface StubServiceInterface
+{
+}

--- a/tests/Stubs/TestGetCurrentUser.php
+++ b/tests/Stubs/TestGetCurrentUser.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+use LaminasAttributeController\Security\GetCurrentUser;
+
+final class TestGetCurrentUser implements GetCurrentUser
+{
+    private ?User $user = null;
+
+    public function auth(User $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getCurrentUser(): ?User
+    {
+        return $this->user;
+    }
+}

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+final readonly class User
+{
+    public function __construct(private int $id, private string $email)
+    {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+}

--- a/tests/Validation/MapRequestHeaderResolverTest.php
+++ b/tests/Validation/MapRequestHeaderResolverTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Validation;
 
+use Laminas\Http\Exception\InvalidArgumentException;
 use Laminas\Http\Request;
 use Laminas\Router\RouteMatch;
 use LaminasAttributeController\ResolutionContext;
-use Laminas\Http\Exception\InvalidArgumentException;
 use LaminasAttributeController\Validation\AcceptHeader;
 use LaminasAttributeController\Validation\MapRequestHeader;
 use LaminasAttributeController\Validation\MapRequestHeaderResolver;


### PR DESCRIPTION

  - Reorganised test structure under PSR-compliant namespaces, moving controller tests and shared stubs into tests/Unit/... and tests/Stubs.
  - Added a Tests\ PSR-4 autoload-dev rule and composer dump to load stub classes automatically.
  - Expanded controller test coverage by driving entity resolution scenarios (success, not-found, current user) through AttributeActionControllerTest instead of standalone resolver tests.
  - Replaced ad-hoc inline classes with reusable StubService, User, Entity, and TestGetCurrentUser fixtures