### PR TITLE
handle null type error in deserialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,9 @@
   },
 
   "scripts": {
-    "cs": "./vendor/bin/php-cs-fixer fix src",
-    "stan": "./vendor/bin/phpstan"
+    "cs": "./vendor/bin/php-cs-fixer fix cs",
+    "stan": "./vendor/bin/phpstan",
+    "test": "./vendor/bin/phpunit -vvv"
   },
   "autoload": {
     "psr-4": {

--- a/src/Validation/MapRequestHeader.php
+++ b/src/Validation/MapRequestHeader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasAttributeController\Validation;
 
 use Attribute;
+
 #[Attribute(Attribute::TARGET_PARAMETER)]
 final readonly class MapRequestHeader
 {

--- a/tests/AttributeActionControllerTest.php
+++ b/tests/AttributeActionControllerTest.php
@@ -36,6 +36,7 @@ use Tests\Stubs\StubService;
 use Tests\Stubs\StubServiceInterface;
 use Tests\Stubs\TestGetCurrentUser;
 use Tests\Stubs\User;
+
 use function get_class;
 
 class AttributeActionControllerTest extends TestCase
@@ -112,7 +113,7 @@ class AttributeActionControllerTest extends TestCase
     {
         return [
             'case without parameters' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/user', methods: ['GET'], name: 'user_index')]
                     public function indexAction(): array
                     {
@@ -123,7 +124,7 @@ class AttributeActionControllerTest extends TestCase
                 'expected' => ['status' => 'User created'],
             ],
             'case with query param' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/user/filter', methods: ['GET'], name: 'user_filter')]
                     public function filterUserAction(#[QueryParam('filter')] ?string $filter = null): array
                     {
@@ -134,7 +135,7 @@ class AttributeActionControllerTest extends TestCase
                 'expected' => ['filter' => 'active'],
             ],
             'case with required query param' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/user/filter', methods: ['GET'], name: 'user_filter')]
                     public function filterUserAction(#[QueryParam('filter', required: true)] string $filter): array
                     {
@@ -147,7 +148,7 @@ class AttributeActionControllerTest extends TestCase
                 'exceptionMessage' => "Query parameter 'filter' is required",
             ],
             'case with incorrect route (404)' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/user', methods: ['GET'], name: 'user')]
                     public function filterUserAction(): array
                     {
@@ -160,7 +161,7 @@ class AttributeActionControllerTest extends TestCase
                 'exceptionMessage' => 'RouteMatch not found',
             ],
             'case with injection' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/logger', methods: ['GET'], name: 'logger')]
                     public function logAction(StubServiceInterface $service): array
                     {
@@ -171,7 +172,7 @@ class AttributeActionControllerTest extends TestCase
                 'expected' => [StubService::class],
             ],
             'current user' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/route', methods: ['GET'], name: 'route')]
                     public function findAction(#[CurrentUser] User $client): array
                     {
@@ -182,7 +183,7 @@ class AttributeActionControllerTest extends TestCase
                 'expected' => ['test-auth@client.com'],
             ],
             'current user without type' => [
-                'controller' => new class extends AttributeActionController {
+                'controller' => new class () extends AttributeActionController {
                     #[Route(path: '/route', methods: ['GET'], name: 'route')]
                     public function findAction(StubServiceInterface $inject, #[CurrentUser] $client): array
                     {
@@ -202,7 +203,7 @@ class AttributeActionControllerTest extends TestCase
         $entityManager = $this->createMock(EntityManagerInterface::class);
 
         $entityManager->method('getRepository')->willReturnCallback(function (string $class) {
-            return new class($class) implements ObjectRepository {
+            return new class ($class) implements ObjectRepository {
                 public function __construct(private readonly string $class)
                 {
                 }

--- a/tests/Validation/MapRequestHeaderResolverTest.php
+++ b/tests/Validation/MapRequestHeaderResolverTest.php
@@ -31,7 +31,7 @@ final class MapRequestHeaderResolverTest extends TestCase
 
     public function testThrowsWhenTypeIsUnsupported(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader] int $header): void
             {
             }
@@ -46,7 +46,7 @@ final class MapRequestHeaderResolverTest extends TestCase
     {
         $this->request->getHeaders()->addHeaderLine('user-agent', 'Symfony');
 
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('user-agent')] string $userAgent): void
             {
             }
@@ -62,7 +62,7 @@ final class MapRequestHeaderResolverTest extends TestCase
     {
         $this->request->getHeaders()->addHeaderLine('accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8');
 
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('accept')] array $accept): void
             {
             }
@@ -82,7 +82,7 @@ final class MapRequestHeaderResolverTest extends TestCase
     {
         $this->request->getHeaders()->addHeaderLine('accept-language', 'en-us,en;q=0.5');
 
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('accept-language')] array $languages): void
             {
             }
@@ -100,7 +100,7 @@ final class MapRequestHeaderResolverTest extends TestCase
     {
         $this->request->getHeaders()->addHeaderLine('accept', 'text/html,application/xhtml+xml');
 
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('accept')] AcceptHeader $accept): void
             {
             }
@@ -114,7 +114,7 @@ final class MapRequestHeaderResolverTest extends TestCase
 
     public function testUsesDefaultValueWhenHeaderMissing(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('x-header')] string $header = 'fallback'): void
             {
             }
@@ -127,7 +127,7 @@ final class MapRequestHeaderResolverTest extends TestCase
 
     public function testAllowsNullableParameters(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('x-header')] ?string $header): void
             {
             }
@@ -140,7 +140,7 @@ final class MapRequestHeaderResolverTest extends TestCase
 
     public function testThrowsWhenHeaderMissingAndNotNullable(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('x-header')] string $header): void
             {
             }
@@ -154,7 +154,7 @@ final class MapRequestHeaderResolverTest extends TestCase
 
     public function testReturnsEmptyArrayWhenHeaderMissingForArrayType(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function action(#[MapRequestHeader('x-header')] array $headers): void
             {
             }

--- a/tests/Validation/MapRequestPayloadResolverTest.php
+++ b/tests/Validation/MapRequestPayloadResolverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Validation;
+
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
+use Laminas\Http\Request;
+use Laminas\Router\RouteMatch;
+use LaminasAttributeController\ResolutionContext;
+use LaminasAttributeController\Validation\ApiSymfonyValidatorChainException;
+use LaminasAttributeController\Validation\MapRequestPayload;
+use LaminasAttributeController\Validation\MapRequestPayloadResolver;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Validator\Validation;
+use TypeError;
+
+final class MapRequestPayloadResolverTest extends TestCase
+{
+    /**
+     * @throws \ReflectionException
+     */
+    public function testConvertsTypeErrorIntoValidationException(): void
+    {
+        $request = new Request();
+        $request->getHeaders()->addHeaderLine('Content-Type', 'application/json');
+        $request->setContent('{"name":null}');
+
+        $serializer = new class () implements SerializerInterface {
+            public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null): string
+            {
+                return '';
+            }
+
+            public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null)
+            {
+                throw new TypeError('Cannot assign null to property Tests\\Validation\\Dto\\SamplePayload::$name of type string');
+            }
+        };
+
+        $resolver = new MapRequestPayloadResolver($serializer, Validation::createValidator(), $request);
+        $controller = new class () {
+            public function action(#[MapRequestPayload] object $payload): void
+            {
+            }
+        };
+
+        $parameter = (new ReflectionMethod($controller, 'action'))->getParameters()[0];
+        $context = new ResolutionContext($parameter, new RouteMatch([]));
+
+        try {
+            $resolver->resolve($context);
+        } catch (ApiSymfonyValidatorChainException $exception) {
+            self::assertCount(1, $exception->chain);
+            $violation = $exception->chain[0];
+
+            self::assertSame('name', $violation->getPropertyPath());
+            self::assertStringContainsString('This value should not be null', $violation->getMessage());
+
+            return;
+        }
+
+        self::fail('Expected ApiSymfonyValidatorChainException to be thrown for TypeError');
+    }
+}


### PR DESCRIPTION
### PR Title
Handle null-to-non-nullable deserialization as a validation error (NotNull)

### Summary
Converts `TypeError` raised during object deserialization when `null` is assigned to a non-nullable property into a consistent API validation error (`ApiSymfonyValidatorChainException`) with a `NotNull` violation and an accurate `propertyPath`.
 Covered only in MapRequestPayload because in Query expected as all property is nullable

### Context / Problem
When deserializing request payload into a DTO, if the input contains `null` for a non-nullable property, `JMS Serializer` throws a `TypeError` like:
```
Cannot assign null to property Some\Dto::$field of type string
```
Previously, this leaked as an internal error (often mapped to HTTP 500) and did not provide a structured validation response for clients.

### What’s changed
- In `MapRequestPayloadResolver`, intercept `TypeError` with message containing `"Cannot assign null to property"` and rethrow as `ApiSymfonyValidatorChainException`.
- Build a `ConstraintViolationList` with a single `NotNull` violation (`code = NotNull::IS_NULL_ERROR`).
- Extract and set the correct `propertyPath` from `TypeError` (e.g., `field` from `Some\Dto::$field`). If extraction fails, fall back to the parameter name.

### Before vs After
- Before: Deserializing `{"field": null}` into a DTO where `field` is non-nullable resulted in an unhandled `TypeError` and an inconsistent API response (likely 500).
- After: The same input yields a consistent validation error consumed by the existing exception mapping, returning a client-friendly response (typically HTTP 400) with `NotNull` violation on `field`.

### API / BC Impact
- Behavior change: internal deserialization `TypeError` is now converted to a validation error. This is an improvement for API consumers, but if anyone relied on the raw `TypeError`, they will now receive `ApiSymfonyValidatorChainException` instead.
- No public API changes; only error handling semantics are aligned with validation flow.

### Testing
- Add/adjust tests to cover:
  - JSON payload with `null` for a non-nullable DTO property results in a `NotNull` violation with correct `propertyPath`.
  - Form-encoded payload (`application/x-www-form-urlencoded`) behaves identically.
  - Other validation errors remain unaffected.

### Example
Request body:
```json
{"name": null}
```
DTO:
```php
class CreateUserDto {
    public string $name; // non-nullable
}
```
Response (conceptual):
```json
{
  "errors": [
    {
      "propertyPath": "name",
      "message": "This value should not be null",
      "code": "IS_NULL_ERROR"
    }
  ]
}
```
